### PR TITLE
Changes necessary for Android locale generation

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format documentation
+

--- a/lib/localio.rb
+++ b/lib/localio.rb
@@ -55,6 +55,7 @@ module Localio
                             @localizables[:languages],
                             @localizables[:segments],
                             @configuration.output_path,
+                            @configuration.output_name,
                             @configuration.formatting,
                             @configuration.platform_options
     puts 'Done!'.green

--- a/lib/localio.rb
+++ b/lib/localio.rb
@@ -39,7 +39,8 @@ module Localio
   def self.process_to_memory
     @localizables = Processor.load_localizables @configuration.platform_options,
                                                 @configuration.source_service,
-                                                @configuration.source_options
+                                                @configuration.source_options,
+                                                @configuration.languages
   end
 
   def self.apply_filters

--- a/lib/localio/formatter.rb
+++ b/lib/localio/formatter.rb
@@ -13,6 +13,8 @@ module Formatter
         key.space_to_underscore.strip_tag.camel_case
       when :snake_case
         key.space_to_underscore.strip_tag.downcase
+      when :full_snake_case
+        key.space_to_underscore.split("_").map { |part| part.underscore }.join("_")
       else
         raise ArgumentError, 'Unknown formatting used. Must use :smart, :none, :camel_case or :snake_case'
     end

--- a/lib/localio/formatter.rb
+++ b/lib/localio/formatter.rb
@@ -13,10 +13,10 @@ module Formatter
         key.space_to_underscore.strip_tag.camel_case
       when :snake_case
         key.space_to_underscore.strip_tag.downcase
-      when :full_snake_case
-        key.space_to_underscore.split("_").map { |part| part.underscore }.join("_")
+      when :strict_snake_case
+        key.space_to_underscore.split("_").map { |part| part.strict_underscore }.join("_")
       else
-        raise ArgumentError, 'Unknown formatting used. Must use :smart, :none, :camel_case or :snake_case'
+        raise ArgumentError, 'Unknown formatting used. Must use :smart, :none, :camel_case, :snake_case or :strict_snake_case'
     end
   end
 end

--- a/lib/localio/localizable_writer.rb
+++ b/lib/localio/localizable_writer.rb
@@ -7,10 +7,10 @@ require 'localio/writers/java_properties_writer'
 require 'localio/writers/resx_writer'
 
 module LocalizableWriter
-  def self.write(platform, languages, terms, path, formatter, options)
+  def self.write(platform, languages, terms, path, filename, formatter, options)
     case platform
       when :android
-        AndroidWriter.write languages, terms, path, formatter, options
+        AndroidWriter.write languages, terms, path, filename, formatter, options
       when :ios
         IosWriter.write languages, terms, path, formatter, options
       when :swift

--- a/lib/localio/locfile.rb
+++ b/lib/localio/locfile.rb
@@ -10,6 +10,8 @@ class Locfile
 
   # Specifies the filesystem path where the generated files will be
   dsl_accessor :output_path
+  
+  dsl_accessor :output_name
 
   # Specifies the format for the keys in the localizable file
   #
@@ -37,6 +39,7 @@ class Locfile
     @source_path = nil
     @source_options = nil
     @output_path = './out/'
+    @output_name = ''
     @formatting = :smart
     @languages = []
   end

--- a/lib/localio/locfile.rb
+++ b/lib/localio/locfile.rb
@@ -28,6 +28,8 @@ class Locfile
   # Defined using 'source' ideally
   dsl_accessor :source_service, :source_options
 
+  dsl_accessor :languages
+
   def initialize
     @platform_name = nil
     @platform_options = nil
@@ -36,6 +38,7 @@ class Locfile
     @source_options = nil
     @output_path = './out/'
     @formatting = :smart
+    @languages = []
   end
 
   # Defines the platform

--- a/lib/localio/processor.rb
+++ b/lib/localio/processor.rb
@@ -4,14 +4,14 @@ require 'localio/processors/xlsx_processor'
 require 'localio/processors/csv_processor'
 
 module Processor
-  def self.load_localizables(platform_options, service, options)
+  def self.load_localizables(platform_options, service, options, languages)
     case service
       when :google_drive
         GoogleDriveProcessor.load_localizables platform_options, options
       when :xls
         XlsProcessor.load_localizables platform_options, options
       when :xlsx
-        XlsxProcessor.load_localizables platform_options, options
+        XlsxProcessor.load_localizables platform_options, options, languages
       when :csv
         CsvProcessor.load_localizables platform_options, options
       else

--- a/lib/localio/processor.rb
+++ b/lib/localio/processor.rb
@@ -13,7 +13,7 @@ module Processor
       when :xlsx
         XlsxProcessor.load_localizables platform_options, options, languages
       when :csv
-        CsvProcessor.load_localizables platform_options, options
+        CsvProcessor.load_localizables platform_options, options, languages
       else
         raise ArgumentError, 'Unsupported service! Try with :google_drive, :csv, :xlsx or :xls in the source argument'
     end

--- a/lib/localio/processors/csv_processor.rb
+++ b/lib/localio/processors/csv_processor.rb
@@ -21,7 +21,7 @@ class CsvProcessor
     first_valid_row_index = nil
     last_valid_row_index = nil
 
-    for row in 1..csv_file.length-1
+    for row in 0..csv_file.length-1
       first_valid_row_index = row if csv_file[row][0].to_s.downcase == '[key]'
       last_valid_row_index = row if csv_file[row][0].to_s.downcase == '[end]'
     end

--- a/lib/localio/processors/csv_processor.rb
+++ b/lib/localio/processors/csv_processor.rb
@@ -3,7 +3,7 @@ require 'localio/term'
 
 class CsvProcessor
 
-  def self.load_localizables(platform_options, options)
+  def self.load_localizables(platform_options, options, allowed_languages)
 
     # Parameter validations
     path = options[:path]
@@ -36,8 +36,10 @@ class CsvProcessor
     for column in 1..csv_file[first_valid_row_index].count-1
       col_all = csv_file[first_valid_row_index][column].to_s
       col_all.each_line(' ') do |col_text|
-        default_language = col_text.downcase.gsub('*', '') if col_text.include? '*'
-        languages.store col_text.downcase.gsub('*', ''), column unless col_text.to_s == ''
+        lang = col_text.downcase.gsub('*', '')
+        next unless allowed_languages.include? lang.to_sym
+        default_language = lang if col_text.include? '*'
+        languages.store lang, column unless col_text.to_s == ''
       end
     end
 

--- a/lib/localio/processors/xlsx_processor.rb
+++ b/lib/localio/processors/xlsx_processor.rb
@@ -3,7 +3,7 @@ require 'localio/term'
 
 class XlsxProcessor
 
-  def self.load_localizables(platform_options, options)
+  def self.load_localizables(platform_options, options, allowed_languages)
 
     # Parameter validations
     path = options[:path]
@@ -37,8 +37,10 @@ class XlsxProcessor
     for column in 1..worksheet.rows[first_valid_row_index].count-1
       col_all = worksheet.rows[first_valid_row_index][column].to_s
       col_all.each_line(' ') do |col_text|
-        default_language = col_text.downcase.gsub('*','') if col_text.include? '*'
-        languages.store col_text.downcase.gsub('*',''), column unless col_text.to_s == ''
+        lang = col_text.downcase.gsub('*', '')
+        next unless allowed_languages.include? lang.to_sym
+        default_language = lang if col_text.include? '*'
+        languages.store lang, column unless col_text.to_s == ''
       end
     end
     

--- a/lib/localio/processors/xlsx_processor.rb
+++ b/lib/localio/processors/xlsx_processor.rb
@@ -7,6 +7,7 @@ class XlsxProcessor
 
     # Parameter validations
     path = options[:path]
+    sheet_index = options[:sheet_index] || 0
     raise ArgumentError, ':path attribute is missing from the source, and it is required for xlsx spreadsheets' if path.nil?
 
     override_default = nil
@@ -15,7 +16,7 @@ class XlsxProcessor
     book = SimpleXlsxReader.open path
 
     # TODO we could pass a :page_index in the options hash and get that worksheet instead, defaulting to zero?
-    worksheet = book.sheets.first
+    worksheet = book.sheets[sheet_index]
     raise 'Unable to retrieve the first worksheet from the spreadsheet. Are there any pages?' if worksheet.nil?
 
     # At this point we have the worksheet, so we want to store all the key / values

--- a/lib/localio/processors/xlsx_processor.rb
+++ b/lib/localio/processors/xlsx_processor.rb
@@ -23,7 +23,7 @@ class XlsxProcessor
     first_valid_row_index = nil
     last_valid_row_index = nil
         
-    for row in 1..worksheet.rows.count-1
+    for row in 0..worksheet.rows.count-1
       first_valid_row_index = row if worksheet.rows[row][0].to_s.downcase == '[key]'
       last_valid_row_index = row if worksheet.rows[row][0].to_s.downcase == '[end]'
     end

--- a/lib/localio/string_helper.rb
+++ b/lib/localio/string_helper.rb
@@ -27,6 +27,13 @@ class String
         downcase
   end
 
+  def strict_underscore
+    self.gsub(/::/, '/').
+        gsub(/([A-Z])/, '_\1').
+        tr("-", "_").
+        downcase
+  end
+
   def strip_tag
     self.gsub(/^[\[][a-z][\]]/, '')
   end

--- a/lib/localio/writers/android_writer.rb
+++ b/lib/localio/writers/android_writer.rb
@@ -5,13 +5,14 @@ require 'localio/formatter'
 require 'nokogiri'
 
 class AndroidWriter
-  def self.write(languages, terms, path, formatter, options)
+  def self.write(languages, terms, path, filename, formatter, options)
     puts 'Writing Android translations...'
     default_language = options[:default_language]
 
     languages.keys.each do |lang|
       output_path = File.join(path,"values-#{lang}/")
       output_path = File.join(path,'values/') if default_language == lang
+      output_name = filename || "strings.xml"
 
       # We have now to iterate all the terms for the current language, extract them, and store them into a new array
 
@@ -24,7 +25,7 @@ class AndroidWriter
         segments.segments << segment
       end
 
-      TemplateHandler.process_template 'android_localizable.erb', output_path, 'strings.xml', segments
+      TemplateHandler.process_template 'android_localizable.erb', output_path, output_name, segments
       puts " > #{lang.yellow}"
     end
 

--- a/lib/localio/writers/android_writer.rb
+++ b/lib/localio/writers/android_writer.rb
@@ -39,6 +39,7 @@ class AndroidWriter
   def self.android_parsing(term)
     encoded_term = term.gsub('...', '…').
                         gsub('%@', '%s').
+                        gsub(/<\$(\d)>/, '%\1$s')
 
     REXML::Text.new(encoded_term).to_s.gsub("&apos;", %q(\\\'))
   end

--- a/lib/localio/writers/android_writer.rb
+++ b/lib/localio/writers/android_writer.rb
@@ -3,6 +3,7 @@ require 'localio/segments_list_holder'
 require 'localio/segment'
 require 'localio/formatter'
 require 'nokogiri'
+require 'rexml/text'
 
 class AndroidWriter
   def self.write(languages, terms, path, filename, formatter, options)
@@ -31,13 +32,15 @@ class AndroidWriter
 
   end
 
-  private
-
   def self.android_key_formatter(key)
     key.space_to_underscore.strip_tag.downcase
   end
-  
+
   def self.android_parsing(term)
-    term.gsub('& ','&amp; ').gsub('...', '…').gsub('%@', '%s')
+    encoded_term = term.gsub('...', '…').
+                        gsub('%@', '%s').
+
+    REXML::Text.new(encoded_term).to_s.gsub("&apos;", %q(\\\'))
   end
+
 end

--- a/spec/lib/localio/writers/android_writer_spec.rb
+++ b/spec/lib/localio/writers/android_writer_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe AndroidWriter do
+  it "makes the keys XML safe" do
+    string = "I'm a string that has symbols & is <really> bad for XML"
+    expect(described_class.android_parsing(string)).to eq "I\\'m a string that has symbols &amp; is &lt;really&gt; bad for XML"
+  end
+
+  it "inserts the correct parameter notation" do
+    string = "Hello, <$1> and welcome to the app!"
+    expect(described_class.android_parsing(string)).to eq "Hello, %1$s and welcome to the app!"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'bundler/setup'
+Bundler.setup
+
+require 'localio'
+
+RSpec.configure do |config|
+
+end


### PR DESCRIPTION
We are forking the localio gem in order to make changes that allow it to support the localization process we are implementing. 

My first story was to get it generating the correct Android XML file (replicating https://stash/projects/CC/repos/localization_support/browse/translations/android/values/strings_translatable.xml)

Changes I made in this PR to support that effort were:
-  updating the configuration option to allow a custom file name (since we name the file "strings_translatable" instead of just "strings"
-  adding a configuration option for "allowed languages" so that we could safely ignore non-languages columns in the source file (previously, it would try and treat all columns as "languages")
- allowing the processing of the source to start at the first row
- adding a new key formatting option that correctly converts our combined camel/snake keys (ex: "activityFeed_filter_bySpeaker" into the format that our Android team has chosen to use ("activity_feed_filter_by_speaker")
- Correctly encoding the strings to be XML safe
- Replacing our chosen "generic" parameter placeholder ("Hello <$1>, welcome to <$2>") with the correct Android placeholder ("Hello %1$s, welcome to %2$s")
