### PR TITLE
add parameter parsing for iOS

### DIFF
--- a/lib/localio/writers/ios_writer.rb
+++ b/lib/localio/writers/ios_writer.rb
@@ -18,7 +18,7 @@ class IosWriter
       constant_segments = SegmentsListHolder.new lang
       terms.each do |term|
         key = Formatter.format(term.keyword, formatter, method(:ios_key_formatter))
-        translation = term.values[lang]
+        translation = ios_parsing term.values[lang]
         segment = Segment.new(key, translation, lang)
         segment.key = nil if term.is_comment?
         segments.segments << segment
@@ -40,6 +40,12 @@ class IosWriter
       puts ' > ' + 'LocalizableConstants.h'.yellow
     end
 
+  end
+
+  def self.ios_parsing(term)
+    term.gsub(/<s\$(\d)>/, '%\1$@').#<s$1> -> %1$@ for string/object params
+         gsub(/<d\$(\d)>/, '%\1$d').#<d$1> -> %1$d for integer params
+         gsub(/<c\$(\d)>/, '%\1$s') #<c$1> -> %1$s for char params
   end
 
   private

--- a/spec/lib/localio/writers/ios_writer_spec.rb
+++ b/spec/lib/localio/writers/ios_writer_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe IosWriter do
+  it "inserts the correct string parameter notation" do
+    string = "Hello, <s$1> and welcome to the app!"
+    expect(described_class.ios_parsing(string)).to eq "Hello, %1$@ and welcome to the app!"
+  end
+
+  it "inserts the correct digit parameter notation" do
+    string = "Hello, <d$1> and welcome to the app!"
+    expect(described_class.ios_parsing(string)).to eq "Hello, %1$d and welcome to the app!"
+  end
+
+  it "inserts the correct char parameter notation" do
+    string = "Hello, <c$1> and welcome to the app!"
+    expect(described_class.ios_parsing(string)).to eq "Hello, %1$s and welcome to the app!"
+  end
+end


### PR DESCRIPTION
Because we're using a universal (totally fabricated) notation to generically represent string parameters in our localization spreadsheet, we have to convert that notation to the proper ios notation when writing the file. 

Example: "Hello, <s$1>" becomes "Hello, %1$@"

The intended conversion is as follows: 

| data type | spreadsheet | ios |
| --- | --- | --- |
| string/object | <s1$> | %1$@ |
| integer | <d1$> | %1$d |
| char | <c1$> | %1$c |
