### PR TITLE
escape double quotes in iOS parser

### DIFF
--- a/lib/localio/writers/ios_writer.rb
+++ b/lib/localio/writers/ios_writer.rb
@@ -46,7 +46,8 @@ class IosWriter
   def self.ios_parsing(term)
     term.gsub(/<s\$(\d)>/, '%\1$@').#<s$1> -> %1$@ for string/object params
          gsub(/<d\$(\d)>/, '%\1$d').#<d$1> -> %1$d for integer params
-         gsub(/<c\$(\d)>/, '%\1$s') #<c$1> -> %1$s for char params
+         gsub(/<c\$(\d)>/, '%\1$s').#<c$1> -> %1$s for char params
+         gsub('"', '\\"')
   end
 
   private

--- a/spec/lib/localio/writers/ios_writer_spec.rb
+++ b/spec/lib/localio/writers/ios_writer_spec.rb
@@ -15,4 +15,9 @@ RSpec.describe IosWriter do
     string = "Hello, <c$1> and welcome to the app!"
     expect(described_class.ios_parsing(string)).to eq "Hello, %1$s and welcome to the app!"
   end
+
+  it "escapes double quotes" do
+    string = 'string with "double" quotes in it'
+    expect(described_class.ios_parsing(string)).to eq 'string with \\"double\\" quotes in it'
+  end
 end


### PR DESCRIPTION
There were quite a few double-quoted strings in the German translations, which the iOS app choked on. This escapes them with "\". 
